### PR TITLE
:bug: Fix: Return promise void to be able to catch error inside lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@discordjs/collection": "^1.5.3",
-    "get-urls": "^10.0.0",
+    "get-urls": "^11.0.0",
     "instagram_mqtt": "^1.2.2",
     "instagram-private-api": "^1.45.3",
     "jimp": "^0.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ig-framework",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Object-oriented library for sending and receiving messages via Instagram",
   "main": "src/index.js",
   "types": "./typings/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ig-framework",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Object-oriented library for sending and receiving messages via Instagram",
   "main": "src/index.js",
   "types": "./typings/index.d.ts",

--- a/src/structures/Chat.js
+++ b/src/structures/Chat.js
@@ -262,15 +262,15 @@ class Chat {
    *   .on('end', () => {
    *     message.chat.sendVoice(Buffer.concat(array));
    *   });
-   * 
+   *
    * @example
    * // This is an example of how to convert an mp3 file to the required format
    * const ffmpeg = require('fluent-ffmpeg');
-   * 
+   *
    * const inputPath = media.path;
    * const outputPath = `${media.path.split('.')[0]}.mp4`
    * mediaName = `${media.filename.split('.')[0]}.mp4`;
-   * 
+   *
    * await new Promise((resolve, reject) => {
    *  ffmpeg()
    *    .input(inputPath)
@@ -334,21 +334,24 @@ class Chat {
    * Send a video in the chat (Instagram has a limit of 60 seconds, just accepts Buffer for now)
    * @param   {Buffer}  buffer  The video to send
    * @return  {Promise<Message>}
-   * 
+   *
    */
   sendVideo(buffer) {
     return new Promise((resolve) => {
-      this.threadEntity.broadcastVideo({
-        video: buffer,
-      }).then((upload) => {
-        let itemID = upload.item_id;
-        if (this.typing && !this._disableTypingOnSend) this._keepTypingAlive();
-        this._sentMessagesPromises.set(itemID, resolve);
-        if (this.messages.has(itemID)) {
-          this._sentMessagesPromises.delete(itemID);
-          resolve(this.messages.get(itemID));
-        }
-      })
+      this.threadEntity
+        .broadcastVideo({
+          video: buffer,
+        })
+        .then((upload) => {
+          let itemID = upload.item_id;
+          if (this.typing && !this._disableTypingOnSend)
+            this._keepTypingAlive();
+          this._sentMessagesPromises.set(itemID, resolve);
+          if (this.messages.has(itemID)) {
+            this._sentMessagesPromises.delete(itemID);
+            resolve(this.messages.get(itemID));
+          }
+        });
     });
   }
 

--- a/src/structures/Client.js
+++ b/src/structures/Client.js
@@ -349,7 +349,7 @@ class Client extends EventEmitter {
       const ig = withFbns(withRealtime(new IgApiClient()));
       // ig.request.end$.subscribe(Util.saveFile(ig));
       ig.state.generateDevice(username);
-  
+
       const state = Util.readFile();
       if (state) {
         await ig.importState(state);
@@ -363,7 +363,7 @@ class Client extends EventEmitter {
       });
       this.cache.users.set(this.user.id, this.user);
       this.emit("debug", "logged", this.user);
-  
+
       const threads = [
         ...(await ig.feed.directInbox().items()),
         ...(await ig.feed.directPending().items()),
@@ -378,14 +378,16 @@ class Client extends EventEmitter {
       ig.realtime.on("message", (data) => this.handleRealtimeReceive(data));
       ig.realtime.on("error", console.error);
       ig.realtime.on("close", () => console.error("RealtimeClient closed"));
-  
+
       await ig.realtime.connect({
         graphQlSubs: [
           // these are some subscriptions
           GraphQLSubscriptions.getAppPresenceSubscription(),
           GraphQLSubscriptions.getZeroProvisionSubscription(ig.state.phoneId),
           GraphQLSubscriptions.getDirectStatusSubscription(),
-          GraphQLSubscriptions.getDirectTypingSubscription(ig.state.cookieUserId),
+          GraphQLSubscriptions.getDirectTypingSubscription(
+            ig.state.cookieUserId
+          ),
           GraphQLSubscriptions.getAsyncAdSubscription(ig.state.cookieUserId),
         ],
         // optional
@@ -397,11 +399,11 @@ class Client extends EventEmitter {
       });
       // PartialObserver<FbnsNotificationUnknown>
       ig.fbns.on("push", (data) => this.handleFbnsReceive(data));
-  
+
       await ig.fbns.connect({
         autoReconnect: true,
       });
-  
+
       this.ig = ig;
       this.ready = true;
       this.emit("connected");
@@ -418,7 +420,7 @@ class Client extends EventEmitter {
         success: true,
         error: null,
       };
-    } catch (err) {  
+    } catch (err) {
       return {
         success: false,
         error: err?.message,

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -47,8 +47,8 @@ class Message {
       data.item_type === "link"
         ? "text"
         : data.item_type === "animated_media"
-          ? "media"
-          : data.item_type;
+        ? "media"
+        : data.item_type;
     /**
      * @type {number}
      * The timestamp the message was sent at
@@ -169,16 +169,25 @@ class Message {
         isLike: true,
         isAnimated: false,
         isSticker: false,
-        url: ((data?.media?.video_versions?.length >= 1 && data?.media?.video_versions[0]?.url) || data?.media?.image_versions2?.candidates[0]?.url),
-        type: data?.media?.video_versions?.length >= 1 ? "video" : "image"
+        url:
+          (data?.media?.video_versions?.length >= 1 &&
+            data?.media?.video_versions[0]?.url) ||
+          data?.media?.image_versions2?.candidates[0]?.url,
+        type: data?.media?.video_versions?.length >= 1 ? "video" : "image",
       };
     } else if (data.item_type === "raven_media") {
       this.mediaData = {
         isLike: true,
         isAnimated: false,
         isSticker: false,
-        url: ((data?.visual_media?.media?.video_versions?.length >= 1 && data?.visual_media?.media?.video_versions[0]?.url) || data?.visual_media?.media?.image_versions2?.candidates[0]?.url),
-        type: data?.visual_media?.media?.video_versions?.length >= 1 ? "video" : "image"
+        url:
+          (data?.visual_media?.media?.video_versions?.length >= 1 &&
+            data?.visual_media?.media?.video_versions[0]?.url) ||
+          data?.visual_media?.media?.image_versions2?.candidates[0]?.url,
+        type:
+          data?.visual_media?.media?.video_versions?.length >= 1
+            ? "video"
+            : "image",
       };
     } else if (data.item_type === "media_share") {
       this.mediaShareData = {
@@ -194,9 +203,15 @@ class Message {
         reel_type: data.reel_share.type,
         reel_owner_id: data.reel_share.reel_owner_id,
         text: data.reel_share.text,
-        url: (data?.reel_share?.media?.video_versions?.length >= 1 && data?.reel_share?.media?.video_versions[0]?.url) || data?.reel_share?.media?.image_versions2?.candidates[0]?.url,
-        type: data?.reel_share?.media?.video_versions?.length >= 1 ? "video" : "image",
-      }
+        url:
+          (data?.reel_share?.media?.video_versions?.length >= 1 &&
+            data?.reel_share?.media?.video_versions[0]?.url) ||
+          data?.reel_share?.media?.image_versions2?.candidates[0]?.url,
+        type:
+          data?.reel_share?.media?.video_versions?.length >= 1
+            ? "video"
+            : "image",
+      };
     }
     /**
      * @typedef {object} MessageVoiceData
@@ -210,9 +225,9 @@ class Message {
     this.voiceData =
       this.type === "voice_media"
         ? {
-          duration: data.voice_media.media.audio.duration,
-          sourceURL: data.voice_media.media.audio.audio_src,
-        }
+            duration: data.voice_media.media.audio.duration,
+            sourceURL: data.voice_media.media.audio.audio_src,
+          }
         : undefined;
 
     // handle promises
@@ -254,11 +269,11 @@ class Message {
     this.likes =
       "reactions" in data
         ? data.reactions.likes.map((r) => {
-          return {
-            userID: r.sender_id,
-            timestamp: r.timestamp,
-          };
-        })
+            return {
+              userID: r.sender_id,
+              timestamp: r.timestamp,
+            };
+          })
         : [];
   }
 
@@ -342,9 +357,10 @@ class Message {
    */
   reply(content) {
     return this.chat.sendMessage(
-      `${this.client.options.disableReplyPrefix
-        ? ""
-        : `@${this.author.username}, `
+      `${
+        this.client.options.disableReplyPrefix
+          ? ""
+          : `@${this.author.username}, `
       }${content}`
     );
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -35,7 +35,7 @@ declare module "node-ig-framework" {
     public createChat(userIDs: number[]): Promise<Chat>;
     public fetchChat(chatID: string, force?: boolean): Promise<Chat>;
     public fetchUser(query: string, force?: boolean): Promise<User>;
-    public logout(): void;
+    public logout(): Promise<void>;
     public login(username: string, password: string): Promise<LoginResponse>;
     public toJSON(): ClientJSON;
 


### PR DESCRIPTION
In my application, when I try to logout my Instagram account after failed login attempt, I get the following error:
TypeError: Cannot read properties of null (reading 'account')
    at Client.logout (\node_modules\node-ig-framework\src\structures\Client.js:319:19)

This error freezes my application and because the error is inside a lib, I can't catch it, so I changed my local lib return value to Promise so I'm able to add a .catch when calling logout function and prevent my application of been broken.